### PR TITLE
USBカメラのパラメータの追加

### DIFF
--- a/launch/run_robot_shm.launch
+++ b/launch/run_robot_shm.launch
@@ -45,6 +45,9 @@
     </group>
     <group if="$(arg use_camera)">
         <node pkg="usb_cam" type="usb_cam_node" name="usb_cam">
+           <param name="pixel_format" value="mjpeg" />
+           <param name="image_width"  value="640" />
+           <param name="image_height" value="480" />
         </node>
     </group>
 </launch> 


### PR DESCRIPTION
ros/one環境でusb_camを使用したときにパラメータなしで動作しなかったため，パラメータを設定．(launch/run_robot_shm.launch)
