### PR TITLE
launchファイルの再修正

### DIFF
--- a/launch/run_robot_shm.launch
+++ b/launch/run_robot_shm.launch
@@ -51,9 +51,5 @@
            <param name="image_width"  value="640" />
            <param name="image_height" value="480" />
         </node>
-        <node pkg="image_transport"
-          type="republish"
-          name="image_republish"
-          args="raw in:=/$(arg robot_name)/Camera0/color/image_raw compressed out:=/$(arg robot_name)/Camera0/color/image" />
     </group>
 </launch>


### PR DESCRIPTION
relayed #9 

launchファイルで固定のCompressedImageをpublishするノードを追加していたが，pluginを入れれば不要な話だったため，元に戻す．